### PR TITLE
Предлагаю перевести компонент на использование config flow

### DIFF
--- a/custom_components/r4s_kettler/.translations/en.json
+++ b/custom_components/r4s_kettler/.translations/en.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "title": "Redmond SkyKettle",
+    "step": {
+      "user": {
+        "title": "Setup a new device",
+        "description": "Details can be found here:\nhttps://github.com/mavrikkk/ha_kettler/blob/master/README.md",
+        "data": {
+          "device": "Bluetooth device",
+          "mac": "Kettle's MAC address",
+          "password": "Password (8 byte length)",
+          "scan_interval": "Scan interval (seconds)"
+        }
+      }
+    },
+    "error": {
+      "wrong_password": "Password is not 8 byte length",
+      "wrong_mac": "MAC is malformed"
+    },
+    "abort": {
+      "already_configured": "Integration for this device is already configured"
+    }
+  }
+}

--- a/custom_components/r4s_kettler/.translations/ru.json
+++ b/custom_components/r4s_kettler/.translations/ru.json
@@ -1,0 +1,24 @@
+{
+  "config": {
+    "title": "Redmond SkyKettle",
+    "step": {
+      "user": {
+        "title": "Настройте новое устройство",
+        "description": "Детальную информацию можно найти здесь:\nhttps://github.com/mavrikkk/ha_kettler/blob/master/README.md",
+        "data": {
+          "device": "Используемое устройство bluetooth",
+          "mac": "MAC адрес чайника",
+          "password": "Пароль (длиной 16 символов)",
+          "scan_interval": "Интервал обновления (секунды)"
+        }
+      }
+    },
+    "error": {
+      "wrong_password": "Пароль неверной длины",
+      "wrong_mac": "MAC невалиден"
+    },
+    "abort": {
+      "already_configured": "Интеграция для этого устройства уже создана"
+    }
+  }
+}

--- a/custom_components/r4s_kettler/config_flow.py
+++ b/custom_components/r4s_kettler/config_flow.py
@@ -1,0 +1,71 @@
+from . import DOMAIN
+from datetime import timedelta
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_DEVICE,
+    CONF_MAC,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL
+)
+
+from re import match as matches
+import voluptuous as vol
+
+DEFAULT_DEVICE = 'hci0'
+DEFAULT_SCAN_INTERVAL = 60
+
+@config_entries.HANDLERS.register(DOMAIN)
+class RedmondKettlerConfigFlow(config_entries.ConfigFlow):
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    async def async_step_user(self, user_input={}):
+        if user_input:
+            return await self.create_entry_if_valid(user_input)
+
+        return self.show_form()
+
+    def show_form(self, user_input={}, errors={}):
+        device = user_input.get(CONF_DEVICE, DEFAULT_DEVICE)
+        mac = user_input.get(CONF_MAC)
+        password = user_input.get(CONF_PASSWORD)
+        scan_interval = user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        SCHEMA = vol.Schema({
+            vol.Required(CONF_DEVICE, default=device): str,
+            vol.Required(CONF_MAC, default=mac): str,
+            vol.Required(CONF_PASSWORD, default=password): str,
+            vol.Optional(CONF_SCAN_INTERVAL, default=scan_interval): int
+        })
+        return self.async_show_form(
+            step_id='user', data_schema=SCHEMA, errors=errors
+        )
+
+    async def create_entry_if_valid(self, user_input):
+        mac = user_input.get(CONF_MAC)
+        password = user_input.get(CONF_PASSWORD)
+        identifier = f'{DOMAIN}[{mac}]'
+        if identifier in self._async_current_ids():
+            return self.async_abort(reason='already_configured')
+
+        mac_pattern = '^' + '[\:\-]'.join(['([0-9a-f]{2})']*6) + '$'
+        if not matches(mac_pattern, mac.lower()):
+            return self.show_form(
+                user_input=user_input,
+                errors={
+                    'base': 'wrong_mac'
+                }
+            )
+
+        if len(password) != 16:
+            return self.show_form(
+                user_input=user_input,
+                errors={
+                    'base': 'wrong_password'
+                }
+            )
+
+        await self.async_set_unique_id(identifier)
+        return self.async_create_entry(
+            title=mac, data=user_input
+        )

--- a/custom_components/r4s_kettler/light.py
+++ b/custom_components/r4s_kettler/light.py
@@ -2,21 +2,19 @@
 # coding: utf-8
 
 from . import DOMAIN
-from homeassistant.components.light import (ATTR_RGB_COLOR, ATTR_HS_COLOR, SUPPORT_COLOR, Light, )
 
+from homeassistant.components.light import (
+    ATTR_RGB_COLOR,
+    ATTR_HS_COLOR,
+    SUPPORT_COLOR,
+    Light
+)
 
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None) -> None:
-
-    if discovery_info is None:
-        return
-
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Setup sensor platform."""
     kettler = hass.data[DOMAIN]["kettler"]
-    async_add_entities([RedmondLight(kettler)])
 
-
-
-
+    async_add_entities([RedmondLight(kettler)], True)
 
 class RedmondLight(Light):
 
@@ -61,3 +59,7 @@ class RedmondLight(Light):
 
     async def async_turn_off(self, **kwargs):
         await self._kettler.stopNightColor()
+
+    @property
+    def unique_id(self):
+        return f'{DOMAIN}[{self._kettler._mac}][{self._name}]'

--- a/custom_components/r4s_kettler/manifest.json
+++ b/custom_components/r4s_kettler/manifest.json
@@ -1,8 +1,9 @@
 {
   "domain": "r4s_kettler",
   "name": "r4s_kettler",
-  "documentation": "https://www.example.com",
+  "documentation": "https://github.com/mavrikkk/ha_kettler/blob/master/README.md",
   "dependencies": [],
   "codeowners": ["@mavrikk"],
-  "requirements": ["pexpect"]
+  "requirements": ["pexpect"],
+  "config_flow": true
 }

--- a/custom_components/r4s_kettler/sensor.py
+++ b/custom_components/r4s_kettler/sensor.py
@@ -11,17 +11,11 @@ ATTR_WATTS_MEASURE = 'kW * h'
 ATTR_ALLTIME_MEASURE = 'h'
 ATTR_TIMES_MEASURE = 'times'
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None) -> None:
-
-    if discovery_info is None:
-        return
-
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Setup sensor platform."""
     kettler = hass.data[DOMAIN]["kettler"]
-    async_add_entities([RedmondSensor(kettler)])
 
-
-
-
+    async_add_entities([RedmondSensor(kettler)], True)
 
 class RedmondSensor(Entity):
 
@@ -53,3 +47,7 @@ class RedmondSensor(Entity):
     @property
     def state(self) -> str:
         return self._kettler._time_upd
+
+    @property
+    def unique_id(self):
+        return f'{DOMAIN}[{self._kettler._mac}][{self._name}]'

--- a/custom_components/r4s_kettler/switch.py
+++ b/custom_components/r4s_kettler/switch.py
@@ -4,21 +4,15 @@
 from . import DOMAIN
 from homeassistant.components.switch import SwitchDevice
 
-
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None) -> None:
-
-    if discovery_info is None:
-        return
-
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Setup sensor platform."""
     kettler = hass.data[DOMAIN]["kettler"]
-    async_add_entities([RedmondSwitchAuthorize(kettler)])
-    async_add_entities([RedmondSwitchBacklight(kettler)])
-    async_add_entities([RedmondSwitchHold(kettler)])
 
-
-
-
+    async_add_entities([
+        RedmondSwitchAuthorize(kettler),
+        RedmondSwitchBacklight(kettler),
+        RedmondSwitchHold(kettler)
+    ], True)
 
 class RedmondSwitchBacklight(SwitchDevice):
 
@@ -51,7 +45,9 @@ class RedmondSwitchBacklight(SwitchDevice):
         self._kettler._usebacklight = False
         await self._kettler.modeUpdate()
 
-
+    @property
+    def unique_id(self):
+        return f'{DOMAIN}[{self._kettler._mac}][{self._name}]'
 
 
 
@@ -86,6 +82,9 @@ class RedmondSwitchHold(SwitchDevice):
         self._kettler._hold = False
         await self._kettler.modeUpdate()
 
+    @property
+    def unique_id(self):
+        return f'{DOMAIN}[{self._kettler._mac}][{self._name}]'
 
 
 
@@ -119,3 +118,7 @@ class RedmondSwitchAuthorize(SwitchDevice):
 
     async def async_turn_off(self, **kwargs):
         pass
+
+    @property
+    def unique_id(self):
+        return f'{DOMAIN}[{self._kettler._mac}][{self._name}]'

--- a/custom_components/r4s_kettler/water_heater.py
+++ b/custom_components/r4s_kettler/water_heater.py
@@ -1,24 +1,29 @@
 #!/usr/local/bin/python3
 # coding: utf-8
 
-from homeassistant.components.water_heater import (WaterHeaterDevice, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE, STATE_ELECTRIC, ATTR_TEMPERATURE)
-from homeassistant.const import (STATE_UNKNOWN, STATE_OFF, TEMP_CELSIUS)
 from . import DOMAIN
+
+from homeassistant.components.water_heater import (
+    WaterHeaterDevice,
+    SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_OPERATION_MODE,
+    STATE_ELECTRIC,
+    ATTR_TEMPERATURE
+)
+from homeassistant.const import (
+    STATE_UNKNOWN,
+    STATE_OFF,
+    TEMP_CELSIUS
+)
 
 OPERATION_LIST = [STATE_OFF, STATE_ELECTRIC]
 SUPPORT_FLAGS_HEATER = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE)
 
-
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None) -> None:
-    if discovery_info is None:
-        return
-
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Setup sensor platform."""
     kettler = hass.data[DOMAIN]["kettler"]
-    async_add_entities([RedmondWaterHeater(kettler)])
 
-
-
+    async_add_entities([RedmondWaterHeater(kettler)], True)
 
 
 class RedmondWaterHeater(WaterHeaterDevice):
@@ -27,8 +32,6 @@ class RedmondWaterHeater(WaterHeaterDevice):
         self._name = 'redmondkettler'
         self._icon = 'mdi:kettle'
         self._kettler = kettler
-
-
 
     ### for HASS
     @property
@@ -106,3 +109,7 @@ class RedmondWaterHeater(WaterHeaterDevice):
     @property
     def icon(self):
         return self._icon
+
+    @property
+    def unique_id(self):
+        return f'{DOMAIN}[{self._kettler._mac}][{self._name}]'


### PR DESCRIPTION
Для начала хочу поблагодарить за большую работу по расковыриванию протокола. Компонент отличный и потому вдохновляет сделать его еще лучше. Любое предлагаемое изменение готов обсудить.

Суть:
У меня не получилось красиво и оставить конфигурацию через yaml, и добавить config flow, поэтому я выпилил всё связанное с ямлом к чертям.
<img width="456" alt="Снимок экрана 2020-04-08 в 18 40 14" src="https://user-images.githubusercontent.com/9576189/78805578-3fdca180-79ca-11ea-9dda-5710c7f46f66.png">

В форме наличествуют проверки: валидности мака, длины пароля и дубля конфига.
Если второй раз добавляя указать тот же мак, то система скажет "уже есть" и прервет добавление.
Если указать невалидный мак или пароль неверной длины, то подсказка об этом вылезет в том же окне и будет ждать исправлений, не давая продолжить с невалидными данными.

**Config flow**: _не требует_ залезания в текстовые файлы, _не требует_ перезагрузки для добавления/удаления конфигурации, _позволяет уже сейчас добавить несколько чайников_ в один сетап.
Так же для каждой сущности в интеграции теперь генерируется **unique_id**, что позволяет позже прямо из веб-интерфейса, без перезагрузок менять **entity_id** на любой удобный.
<img width="446" alt="Снимок экрана 2020-04-08 в 18 55 39" src="https://user-images.githubusercontent.com/9576189/78805888-acf03700-79ca-11ea-80da-bbf1cdd6b094.png">